### PR TITLE
Fixing Bug 4

### DIFF
--- a/Assets/scripts/GameManager.cs
+++ b/Assets/scripts/GameManager.cs
@@ -33,6 +33,7 @@ public class GameManager : MonoBehaviour {
 	}
 
 	void OnEnable(){
+		CountdownText.OnCountdownFinished += OnCountdownFinished;
 		TapController.OnPlayerDied += OnPlayerDied;
 		TapController.OnPlayerScored += OnPlayerScored;
 	


### PR DESCRIPTION
Ketika play, countdown game berhenti di angka 1, terdapat error Null Reference yang mengacu pada script CountdownText.cs. Solving Bug dilakukan dengan cara melakukan breakpoint pada line code function OnCountdownFinished () dan ternyata valuenya null. Kemudian mengecek pada script GameManager.cs, pada function OnEnable() ternyata tidak terdapat CountdownText.OnCountdownFinished += OnCountdownFinished; yang seharusnya menjadi value untuk function OnCountdownFinished() pada script CountdownText.cs.