### PR TITLE
Fixing Bug 5

### DIFF
--- a/Assets/scripts/GameManager.cs
+++ b/Assets/scripts/GameManager.cs
@@ -25,7 +25,7 @@ public class GameManager : MonoBehaviour {
 	int score = 0;
 	bool gameOver = true;
 
-	public bool GameOver { get { return !gameOver; } }
+	public bool GameOver { get { return gameOver; } }
 
 	void Awake(){
 	


### PR DESCRIPTION
Pada script GameManager.cs, di bagian getter variabel gameover yang diambil bernilai terbalik karena terdapat simbol negasi sehingga ketika dipakai di fungsi bawahnya maka gameplay yang harusnya berjalan malah terhenti.